### PR TITLE
Bugfix - OAF Version 0.42.0.2

### DIFF
--- a/app/models/foi_attachment.rb
+++ b/app/models/foi_attachment.rb
@@ -49,9 +49,41 @@ class FoiAttachment < ApplicationRecord
   BODY_MAX_TRIES = 3
   BODY_MAX_DELAY = 5
 
+  def directory
+    if file.attached?
+      warn <<~DEPRECATION.squish
+        [DEPRECATION] FoiAttachment#directory shouldn't be used when using
+        `ActiveStorage` backed file stores. This method will be removed
+        in 0.42.
+      DEPRECATION
+      return
+    end
+
+    base_dir = File.expand_path(File.join(File.dirname(__FILE__), "../../cache", "attachments_#{Rails.env}"))
+    return File.join(base_dir, self.hexdigest[0..2])
+  end
+
+  def filepath
+    if file.attached?
+      warn <<~DEPRECATION.squish
+        [DEPRECATION] FoiAttachment#filepath shouldn't be used when using
+        `ActiveStorage` backed file stores. This method will be removed
+        in 0.42.
+      DEPRECATION
+      return
+    end
+
+    File.join(self.directory, self.hexdigest)
+  end
+
   def delete_cached_file!
     @cached_body = nil
-    file.purge if file.attached?
+
+    if file.attached?
+      file.purge
+    elsif File.exist?(filepath)
+      File.delete(filepath)
+    end
   end
 
   def body=(d)
@@ -69,21 +101,33 @@ class FoiAttachment < ApplicationRecord
   end
 
   # raw body, encoded as binary
-  def body(tries: 0, delay: 1)
-    return @cached_body if @cached_body
-
-    if file.attached?
-      @cached_body = file.download
-    else
-      # we've lost our cached attachments for some reason.  Reparse them.
-      raise if tries > BODY_MAX_TRIES
-      sleep [delay, BODY_MAX_DELAY].min
-
-      self.incoming_message.parse_raw_email!(true)
-      reload
-
-      body(tries: tries + 1, delay: delay * 2)
+  def body
+    if @cached_body.nil?
+      tries = 0
+      delay = 1
+      begin
+        if file.attached?
+          @cached_body = file.download
+        else
+          @cached_body = File.open(filepath, "rb" ) { |file| file.read }
+        end
+      rescue Errno::ENOENT, ActiveStorage::FileNotFoundError
+        # we've lost our cached attachments for some reason.  Reparse them.
+        if tries > BODY_MAX_TRIES
+          raise
+        else
+          sleep delay
+        end
+        tries += 1
+        delay *= 2
+        delay = BODY_MAX_DELAY if delay > BODY_MAX_DELAY
+        force = true
+        self.incoming_message.parse_raw_email!(force)
+        reload
+        retry
+      end
     end
+    return @cached_body
   end
 
   # body as UTF-8 text, with scrubbing of invalid chars if needed

--- a/app/models/raw_email.rb
+++ b/app/models/raw_email.rb
@@ -69,6 +69,45 @@ class RawEmail < ApplicationRecord
     mail.from_addrs.nil? || mail.from_addrs.size == 0
   end
 
+  def directory
+    if file.attached?
+      warn <<~DEPRECATION.squish
+        [DEPRECATION] RawEmail#directory shouldn't be used when using
+        `ActiveStorage` backed file stores. This method will be removed
+        in 0.42.
+      DEPRECATION
+      return
+    end
+
+    if request_id.empty?
+      raise "Failed to find the id number of the associated request: has it been saved?"
+    end
+
+    if Rails.env.test?
+      File.join(Rails.root, 'files/raw_email_test')
+    else
+      File.join(AlaveteliConfiguration::raw_emails_location,
+                request_id[0..2], request_id)
+    end
+  end
+
+  def filepath
+    if file.attached?
+      warn <<~DEPRECATION.squish
+        [DEPRECATION] RawEmail#filepath shouldn't be used when using
+        `ActiveStorage` backed file stores. This method will be removed
+        in 0.42.
+      DEPRECATION
+      return
+    end
+
+    if incoming_message_id.empty?
+      raise "Failed to find the id number of the associated incoming message: has it been saved?"
+    end
+
+    File.join(directory, incoming_message_id)
+  end
+
   def mail
     @mail ||= mail!
   end
@@ -87,7 +126,9 @@ class RawEmail < ApplicationRecord
   end
 
   def data
-    @data ||= file.download if file.attached?
+    return @data ||= file.download if file.attached?
+
+    File.open(filepath, "rb").read
   end
 
   def data_as_text
@@ -131,6 +172,10 @@ class RawEmail < ApplicationRecord
   end
 
   def destroy_file_representation!
-    file.purge if file.attached?
+    if file.attached?
+      file.purge
+    elsif File.exist?(filepath)
+      File.delete(filepath)
+    end
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -98,7 +98,7 @@ Rails.application.configure do
   end
 
   # Allow any IP address in the range 10.10.10.x to access the web console
-  config.web_console.whitelisted_ips = '10.10.10.0/16'
+  config.web_console.whitelisted_ips = ['10.10.10.0/16', '192.168.0.0/16']
 
   # Writes useful log files to debug memory leaks, of the sort where have
   # unintentionally kept references to objects, especially strings.

--- a/config/initializers/alaveteli.rb
+++ b/config/initializers/alaveteli.rb
@@ -10,7 +10,7 @@ load "debug_helpers.rb"
 load "util.rb"
 
 # Application version
-ALAVETELI_VERSION = '0.42.0.1'
+ALAVETELI_VERSION = '0.42.0.2'
 
 # Add new inflection rules using the following format
 # (all these examples are active by default):

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,7 +23,7 @@ RUN git clone https://github.com/vishnubob/wait-for-it.git /tmp/wait-for-it && \
 
 WORKDIR /alaveteli/
 
-RUN gem update --system
+# RUN gem update --system
 RUN gem install sqlite3 -v 1.4.2
 RUN gem install net-imap -v 0.3.8
 RUN gem install mailcatcher -v 0.8.0 --conservative

--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -134,6 +134,16 @@ module AlaveteliConfiguration
     # rubocop:enable Layout/LineLength
   end
 
+  def self.raw_emails_location
+    warn <<~DEPRECATION.squish
+      [DEPRECATION] AlaveteliConfiguration.raw_emails_location will be removed
+      in 0.42. You should have `ActiveStorage` configured but you still haven't
+      migrated all your old files. Please run `bin/rails storage:migrate` to
+      migrate
+    DEPRECATION
+    super
+  end
+
   def self.method_missing(name)
     key = name.to_s.upcase
     if DEFAULTS.has_key?(key.to_sym)

--- a/spec/models/raw_email_spec.rb
+++ b/spec/models/raw_email_spec.rb
@@ -12,6 +12,26 @@ require 'spec_helper'
 
 RSpec.describe RawEmail do
 
+  # DEPRECATION: remove for release 0.42
+  class LegacyRawEmail < RawEmail
+    # This replicates how we used to store RawEmail before switching to
+    # ActiveStorage
+    def data=(d)
+      FileUtils.mkdir_p(directory) unless File.exist?(directory)
+      File.atomic_write(filepath) do |file|
+        file.binmode
+        file.write(d)
+      end
+    end
+  end
+
+  let(:legacy_raw_email) do
+    LegacyRawEmail.create!(
+      incoming_message: FactoryBot.create(:incoming_message),
+      data: 'Hello world'
+    )
+  end
+
   def roundtrip_data(raw_email, data)
     raw_email.data = data
     raw_email.save!
@@ -20,13 +40,28 @@ RSpec.describe RawEmail do
   end
 
   describe 'before destroy callbacks' do
-    let(:raw_email) { FactoryBot.create(:incoming_message).raw_email }
+    shared_examples :destory_file_examples do
+      it 'should delete the directory' do
+        raw_email.run_callbacks(:destroy)
+        expect(File.exist?(raw_email.filepath)).to eq(false)
+      end
 
-    it 'should only delete the directory if it exists' do
-      expect(File).to receive(:delete).once.and_call_original
-      raw_email.run_callbacks(:destroy)
-      expect { raw_email.run_callbacks(:destroy) }.
-        not_to raise_error
+      it 'should only delete the directory if it exists' do
+        expect(File).to receive(:delete).once.and_call_original
+        raw_email.run_callbacks(:destroy)
+        expect { raw_email.run_callbacks(:destroy) }.
+          not_to raise_error
+      end
+    end
+
+    context 'with active storage' do
+      let(:raw_email) { FactoryBot.create(:incoming_message).raw_email }
+      include_examples :destory_file_examples
+    end
+
+    context 'without active storage' do
+      let(:raw_email) { legacy_raw_email }
+      include_examples :destory_file_examples
     end
   end
 
@@ -184,21 +219,33 @@ RSpec.describe RawEmail do
   end
 
   describe '#data' do
-    let(:raw_email) { FactoryBot.create(:incoming_message).raw_email }
 
-    it 'roundtrips data unchanged' do
-      data = roundtrip_data(raw_email, "Hello, world!")
-      expect(data).to eq("Hello, world!")
+    shared_examples :data_unchanged_examples do
+      it 'roundtrips data unchanged' do
+        data = roundtrip_data(raw_email, "Hello, world!")
+        expect(data).to eq("Hello, world!")
+      end
+
+      it 'returns an unchanged binary string with a valid encoding if the data is non-ascii and non-utf-8' do
+        data = roundtrip_data(raw_email, "\xA0")
+
+        expect(data.encoding.to_s).to eq('ASCII-8BIT')
+        expect(data.valid_encoding?).to be true
+        data = data.force_encoding('UTF-8')
+        expect(data).to eq("\xA0")
+      end
     end
 
-    it 'returns an unchanged binary string with a valid encoding if the data is non-ascii and non-utf-8' do
-      data = roundtrip_data(raw_email, "\xA0")
-
-      expect(data.encoding.to_s).to eq('ASCII-8BIT')
-      expect(data.valid_encoding?).to be true
-      data = data.force_encoding('UTF-8')
-      expect(data).to eq("\xA0")
+    context 'with active storage' do
+      let(:raw_email) { FactoryBot.create(:incoming_message).raw_email }
+      include_examples :data_unchanged_examples
     end
+
+    context 'without active storage' do
+      let(:raw_email) { legacy_raw_email }
+      include_examples :data_unchanged_examples
+    end
+
   end
 
   describe '#data_as_text' do


### PR DESCRIPTION
## Relevant issue(s)
N/A

## What does this do?
Reverts 1ab296a370cf19f337e32897b9af881943a408ee
Make some minor changes to the Dockerfile so that I can start a docker instance
Adds some whitelisted IP ranges so that I can see the console when I'm running in Docker

## Why was this needed?
- 1ab296a370cf19f337e32897b9af881943a408ee removes the models that we rely on to be able to run `bundle exec rails storage:migrate`. This PR restores those models.
- The DockerFile and IP Range changes apply only in development but are being added here for ease of use.

## Implementation notes
These changes were manually applied by running `git revert` and testing that I was then able to run `bundle exec rails storage:migrate` 