### PR TITLE
Politely ask Claude to stop driving our site into the ground.

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -12,6 +12,9 @@
 #   http://code.google.com/web/controlcrawlindex/docs/robots_txt.html
 #   http://help.yahoo.com/l/us/yahoo/search/webcrawler/slurp-02.html
 
+User-agent: ClaudeBot
+Disallow: /
+
 User-agent: *
 Disallow: */annotate/*
 Disallow: */new/*


### PR DESCRIPTION
## Relevant issue(s)

## What does this do?
Asks Claudebot to not spider the site. If this isn't respected, we may need to take other action to block the scraping.

## Why was this needed?
At present, when Claude starts spidering the site, it quickly quintuples the number of requests per minute that nginx is handling - and then the requests-per-minute dwindle away to nothing as the machine gradually runs out of CPU and ram, until it eventually OOMs.. and then Claude can start hitting us again.

## Implementation notes
None

## Screenshots

## Notes to reviewer
