### PR TITLE
Cap storage fix

### DIFF
--- a/app/controllers/alaveteli_pro/subscriptions_controller.rb
+++ b/app/controllers/alaveteli_pro/subscriptions_controller.rb
@@ -52,7 +52,9 @@ class AlaveteliPro::SubscriptionsController < AlaveteliPro::BaseController
       @subscription = @pro_account.subscriptions.build
       @subscription.update_attributes(
         plan: params.require(:plan_id),
-        tax_percent: tax_percent,
+        automatic_tax: {
+            enabled: "true"
+        },
         payment_behavior: 'allow_incomplete'
       )
 

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -4,6 +4,14 @@ set :stage, 'staging' unless exists? :stage
 
 configuration = YAML.load_file('config/deploy.yml')[stage]
 
+# Load general_config from local file if it exists, otherwise use defaults
+# The actual configuration will be loaded from the remote server during deployment
+if File.exist?('config/general.yml')
+  general_config = YAML.load_file('config/general.yml')
+else
+  general_config = {}
+end
+
 set :application, 'alaveteli'
 set :scm, :git
 set :deploy_via, :remote_cache
@@ -84,22 +92,32 @@ namespace :deploy do
 
   desc 'Link configuration after a code update'
   task :symlink_configuration do
-    links = {
-      "#{release_path}/config/database.yml" => "#{shared_path}/database.yml",
-      "#{release_path}/config/storage.yml" => "#{shared_path}/storage.yml",
-      "#{release_path}/config/general.yml" => "#{shared_path}/general.yml",
-      "#{release_path}/config/rails_env.rb" => "#{shared_path}/rails_env.rb",
-      "#{release_path}/config/httpd.conf" => "#{shared_path}/httpd.conf",
-      "#{release_path}/config/aliases" => "#{shared_path}/aliases",
-      "#{release_path}/public/foi-live-creation.png" => "#{shared_path}/foi-live-creation.png",
-      "#{release_path}/public/foi-user-use.png" => "#{shared_path}/foi-user-use.png",
-      "#{release_path}/files" => "#{shared_path}/files",
-      "#{release_path}/cache" => "#{shared_path}/cache",
-      "#{release_path}/log" => "#{shared_path}/log",
-      "#{release_path}/tmp/pids" => "#{shared_path}/tmp/pids",
-      "#{release_path}/lib/acts_as_xapian/xapiandbs" => "#{shared_path}/xapiandbs",
-      "#{release_path}/lib/themes" => "#{shared_path}/themes",
-    }
+    # Load general.yml from the remote shared directory
+    general_yml_content = capture("cat #{shared_path}/general.yml")
+    remote_general_config = YAML.load(general_yml_content)
+
+    links = {}
+
+    # Add shared files from general.yml
+    shared_files = remote_general_config['SHARED_FILES'] || []
+    shared_files.each do |file|
+      links["#{release_path}/#{file}"] = "#{shared_path}/#{File.basename(file)}"
+    end
+
+    # Add shared directories from general.yml
+    shared_directories = remote_general_config['SHARED_DIRECTORIES'] || []
+    shared_directories.each do |dir|
+      dir_name = dir.chomp('/')
+      # Map lib/acts_as_xapian/xapiandbs/ to xapiandbs for backward compatibility
+      if dir_name == 'lib/acts_as_xapian/xapiandbs'
+        links["#{release_path}/#{dir_name}"] = "#{shared_path}/xapiandbs"
+      else
+        links["#{release_path}/#{dir_name}"] = "#{shared_path}/#{File.basename(dir_name)}"
+      end
+    end
+
+    # Add themes directory (not in general.yml but always needed)
+    links["#{release_path}/lib/themes"] = "#{shared_path}/themes"
 
     if rbenv_ruby_version
       links["#{release_path}/.rbenv-version"] = "#{shared_path}/rbenv-version"
@@ -117,11 +135,39 @@ namespace :deploy do
   end
 
   after 'deploy:setup' do
-    run "mkdir -p #{shared_path}/files"
-    run "mkdir -p #{shared_path}/cache"
-    run "mkdir -p #{shared_path}/log"
-    run "mkdir -p #{shared_path}/tmp/pids"
-    run "mkdir -p #{shared_path}/xapiandbs"
+    # Check if general.yml exists in shared directory
+    general_yml_exists = capture("test -f #{shared_path}/general.yml && echo 'exists' || echo 'missing'").strip
+
+    if general_yml_exists == 'exists'
+      # Load general.yml from the remote shared directory
+      general_yml_content = capture("cat #{shared_path}/general.yml")
+      remote_general_config = YAML.load(general_yml_content)
+
+      # Create directories for shared directories from general.yml
+      shared_directories = remote_general_config['SHARED_DIRECTORIES'] || []
+      shared_directories.each do |dir|
+        dir_name = dir.chomp('/')
+        # Map lib/acts_as_xapian/xapiandbs/ to xapiandbs for backward compatibility
+        if dir_name == 'lib/acts_as_xapian/xapiandbs'
+          run "mkdir -p #{shared_path}/xapiandbs"
+        else
+          run "mkdir -p #{shared_path}/#{File.basename(dir_name)}"
+        end
+      end
+    else
+      # Fallback to defaults if general.yml doesn't exist yet
+      puts "WARNING: #{shared_path}/general.yml not found. Using default shared directories."
+      run "mkdir -p #{shared_path}/files"
+      run "mkdir -p #{shared_path}/storage"
+      run "mkdir -p #{shared_path}/cache"
+      run "mkdir -p #{shared_path}/log"
+      run "mkdir -p #{shared_path}/tmp/pids"
+      run "mkdir -p #{shared_path}/xapiandbs"
+      run "mkdir -p #{shared_path}/vendor/bundle"
+      run "mkdir -p #{shared_path}/assets"
+    end
+
+    # Always create themes directory (not in general.yml but always needed)
     run "mkdir -p #{shared_path}/themes"
   end
 end

--- a/config/initializers/alaveteli.rb
+++ b/config/initializers/alaveteli.rb
@@ -10,7 +10,7 @@ load "debug_helpers.rb"
 load "util.rb"
 
 # Application version
-ALAVETELI_VERSION = '0.42.0.2'
+ALAVETELI_VERSION = '0.42.0.3'
 
 # Add new inflection rules using the following format
 # (all these examples are active by default):

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -1,3 +1,9 @@
+# 0.42.0.3
+
+## Highlighted Features
+
+* Updates to Capistrano deployment to use SHARED_* values in general.yml
+
 # 0.42.0.1
 
 ## Highlighted Features


### PR DESCRIPTION
## Relevant issue(s)
- https://github.com/openaustralia/righttoknow/issues/984

## What does this do?
Updates the Capistrano deployment process to load symlinked files and directories from the general.yml configuration.

## Why was this needed?
When we run `cap deploy` it should be symlinking stuff that already exists.

## Implementation/Deploy Steps
To test on staging, run `cap -S stage=staging deploy` to deploy to staging.righttoknow.org.au

## Notes to reviewer (Optional)
This has been tested on Staging already (see #34). Doing this to resolve a production affecting bug.